### PR TITLE
Get the plugin install URL with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The fastest way to install and run the plugin is to use the official Grafana doc
 docker run -it \
       -p 3000:3000 \
       --name=tezos-grafana \
-      -e "GF_INSTALL_PLUGINS=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '.[0].assets[0].browser_download_url');ecad-labs-tezos-datasource" \
+      -e "GF_INSTALL_PLUGINS=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].assets[0].browser_download_url');ecad-labs-tezos-datasource" \
       -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=ecad-labs-tezos-datasource" \
       grafana/grafana:latest
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The fastest way to install and run the plugin is to use the official Grafana doc
 docker run -it \
       -p 3000:3000 \
       --name=tezos-grafana \
-      -e "GF_INSTALL_PLUGINS=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].assets[0].browser_download_url');ecad-labs-tezos-datasource" \
+      -e "GF_INSTALL_PLUGINS=$(curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].assets[0].browser_download_url');ecad-labs-tezos-datasource" \
       -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=ecad-labs-tezos-datasource" \
       grafana/grafana:latest
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin allows users to present data from the Tezos chain using only a Tezos
 
 ## Getting started
 
-__Prerequiste: a functioning docker installation, and a Tezos RPC node__
+__Prerequiste: a functioning docker installation, the jq command line tool, and a Tezos RPC node__
 
 The fastest way to install and run the plugin is to use the official Grafana docker image as follows:
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ __Prerequiste: a functioning docker installation, and a Tezos RPC node__
 The fastest way to install and run the plugin is to use the official Grafana docker image as follows:
 
 ```
-docker run --it \
+docker run -it \
       -p 3000:3000 \
-      --name=grafana \
-      -e "GF_INSTALL_PLUGINS=https://github.com/ecadlabs/tezos-grafana-datasource/releases/download/v0.0.2/ecad-labs-tezos-datasource-0.0.2.zip;ecad-labs-tezos-datasource" \
+      --name=tezos-grafana \
+      -e "GF_INSTALL_PLUGINS=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '.[0].assets[0].browser_download_url');ecad-labs-tezos-datasource" \
       -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=ecad-labs-tezos-datasource" \
       grafana/grafana:latest
 ```


### PR DESCRIPTION
Using the following command will get the latest release, that is not a darft or prerelease, download url
```shell
curl -sH "Accept: application/vnd.github.v3+json" https://api.github.com/repos/ecadlabs/tezos-grafana-datasource/releases | jq -r '[.[] | select(.draft == false and .prerelease == false)][0].assets[0].browser_download_url'
```

The command also adds `jq` as a dependency for the docker quickstart and the README should indicate this accordingly

Signed-off-by: GImbrailo <ginoimbrailo@gmail.com>

closes #3 